### PR TITLE
Add Gradio Demo

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,13 +7,15 @@ from dataset.utils import *
 from pathlib import Path
 from dataset import create_dataset, create_loader
 import fire
+import multiprocessing
+import logging
 
-transform = Transform(resize_resolution=480, scale_size=[0.5, 1.0], train=False)
+transform = Transform(resize_resolution=480, scale_size=[
+    0.5, 1.0], train=False)
 device = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
 
 
-def prepare_image(config, image):
-    image.save(config["data_path"] / "images" / "image.jpg")
+def call_expert_scripts(config):
     if len(config['experts']) > 0:
         script_names = ["python experts/generate_depth.py",
                         "python experts/generate_edge.py",
@@ -21,8 +23,24 @@ def prepare_image(config, image):
                         "python experts/generate_objdet.py",
                         "python experts/generate_ocrdet.py",
                         "python experts/generate_segmentation.py"]
-        for script_name in script_names:
-            os.system(script_name)
+        # If you have constrained resources, run the scripts sequentially:
+        # for script_name in script_names:
+        #     os.system(script_name)
+        with multiprocessing.Pool(6) as p:
+            p.map(os.system, script_names)
+
+
+def get_model_input(config):
+    _, test_dataset = create_dataset('caption', config)
+    if len(test_dataset) != 1:
+        logging.warning(
+            "Make sure to empty the helpers/images folder before running the demo. Otherwise you are recomputing for images that aren't shown ")
+    test_loader = create_loader(
+        test_dataset, batch_size=1, num_workers=4, train=False
+    )
+    experts, _ = next(iter(test_loader))
+    return experts
+
 
 def prepare_inputs(image, question, task="caption"):
     image = transform(image, None)
@@ -33,18 +51,18 @@ def prepare_inputs(image, question, task="caption"):
         question = pre_question(question, max_words=50)
     return image, question
 
-def get_experts(config):
-    _, test_dataset = create_dataset('caption', config)
-    test_loader = create_loader(test_dataset, batch_size=1, num_workers=4, train=False)
-    experts, _ = next(iter(test_loader))
+
+def move_to_device(experts):
+    for key in experts:
+        if key == 'obj_detection':
+            experts[key]['label'] = experts[key]['label'].to(device)
+            experts[key]['instance'] = experts[key]['instance'].to(device)
+        else:
+            experts[key] = experts[key].to(device)
     return experts
 
 
-
-def demo(
-        task: str = "vqa",
-        model_name: str = "prismerz_base",
-):
+def demo(task: str = "vqa", model_name: str = "prismerz_base"):
     use_experts = "prismerz" not in model_name
     if use_experts:
         data_path = Path("helpers")
@@ -57,6 +75,8 @@ def demo(
         "label_path": label_path if use_experts else None,
         "freeze": "freeze_vision",
         "image_resolution": 480,
+        "prefix": "" if task == "vqa" else "A picture of",
+        "dataset": "demo"
     }
     if task == "vqa":
         model = PrismerVQA(config)
@@ -64,48 +84,67 @@ def demo(
         model = PrismerCaption(config)
     else:
         raise ValueError(f"Task {task} not supported")
-    state_dict = torch.load(f'logging/{task}_{model_name}/pytorch_model.bin', map_location=device)
+    state_dict = torch.load(
+        f'logging/{task}_{model_name}/pytorch_model.bin', map_location=device
+    )
     model.load_state_dict(state_dict)
     model.eval()
     model = model.to(device)
+    img_path = config["data_path"] / "images" / "image.jpg"
 
     def infer(image, question):
         if use_experts:
-            prepare_image(config, image)
-            experts = get_experts(config)
+            image.save(img_path)
+            call_expert_scripts(config)
+            experts = get_model_input(config)
+
         im, question = prepare_inputs(image, question, task)
         experts = im if not use_experts else experts
-        experts['rgb'] = experts['rgb'].to(device)
+        experts = move_to_device(experts)
 
         with torch.no_grad():
             if task == "caption":
                 answer = model(experts, prefix=question, train=False, inference='generate')
             else:
                 answer = model(experts, [question], train=False, inference='generate')
+
+        if use_experts:
+            img_path.unlink()
+            expert_images = [label_path / key / "helpers" / "images" / "image.png" for key in experts]
+            expert_images = [str(im_path) for im_path in expert_images if img_path.exists()]
+            labels = ["Depth", "Normal", "Segmentation", "Edge", "Object Detection", "OCR Detection"]
+            outs = list(zip(expert_images, labels))
+            return answer[0], outs
+        else:
             return answer[0]
-        
+
+    # Prepare the interface
     model_title = "PrismerZ" if "prismerz" in model_name else "Prismer"
     model_size = model_name.split("_")[-1].capitalize()
     title = f"{model_title} {model_size} {task.capitalize()}"
     if task == "vqa":
         inputs = [grImage(type="pil"), Textbox(placeholder="What is the color of the shirt?")]
-        outputs = Textbox()
         description = f"Visual Question Answering with {model_title} {model_size}"
-        article = ""
         examples = [
-            ["http://images.cocodataset.org/val2017/000000039769.jpg", "How many cats are there?"],
-            ["http://images.cocodataset.org/val2017/000000039769.jpg", "What color is the blanket?"],
+            ["http://images.cocodataset.org/val2017/000000039769.jpg",
+             "How many cats are there?"],
+            ["https://ids.si.edu/ids/deliveryService?max_w=800&id=NPG-NPG_2001_13",
+             "What is the man holding in his hand?"],
         ]
     else:
         inputs = [grImage(type="pil"), Textbox(placeholder="A picture of", interactive=False)]
-        outputs = Textbox()
         description = f"Image Captioning with {model_title} {model_size}"
-        article = ""
         examples = [
             ["http://images.cocodataset.org/val2017/000000039769.jpg", "A picture of"],
+            ["https://ids.si.edu/ids/deliveryService?max_w=800&id=NPG-NPG_2001_13", "A picture of"],
         ]
 
-    gr.Interface(infer, inputs, outputs, title=title, description=description, article=article, examples=examples).launch()
+    if use_experts:
+        outputs = [Textbox(placeholder="Answer", interactive=False),
+                   gr.Gallery(label="Experts")]
+    else:
+        outputs = Textbox(placeholder="Answer", interactive=False)
+    gr.Interface(infer, inputs, outputs, title=title, description=description, examples=examples).launch()
 
 
 if __name__ == "__main__":

--- a/app.py
+++ b/app.py
@@ -2,43 +2,111 @@ import gradio as gr
 from gradio.components import Image as grImage
 from gradio.components import Textbox as Textbox
 from model.prismer_vqa import PrismerVQA
-import yaml
+from model.prismer_caption import PrismerCaption
 from dataset.utils import *
+from pathlib import Path
+from dataset import create_dataset, create_loader
+import fire
 
+transform = Transform(resize_resolution=480, scale_size=[0.5, 1.0], train=False)
 device = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
 
-with open('configs/gradio_vqa.yaml', 'r') as f:
-    config = yaml.load(f, Loader=yaml.Loader)
 
-model = PrismerVQA(config)
-state_dict = torch.load(f'logging/prismerz_vqa/pytorch_model.bin', map_location=device) # , map_location='cuda:0')
-model.load_state_dict(state_dict)
-tokenizer = model.tokenizer
-model.eval()
+def prepare_image(config, image):
+    image.save(config["data_path"] / "images" / "image.jpg")
+    if len(config['experts']) > 0:
+        script_names = ["python experts/generate_depth.py",
+                        "python experts/generate_edge.py",
+                        "python experts/generate_normal.py",
+                        "python experts/generate_objdet.py",
+                        "python experts/generate_ocrdet.py",
+                        "python experts/generate_segmentation.py"]
+        for script_name in script_names:
+            os.system(script_name)
 
-transform = Transform(resize_resolution=config['image_resolution'], scale_size=[0.5, 1.0], train=False)
-
-
-def infer(image, question):
-    with torch.no_grad():
-        image = transform(image, None)
-        image['rgb'] = image['rgb'].unsqueeze(0).to(device)
+def prepare_inputs(image, question, task="caption"):
+    image = transform(image, None)
+    image['rgb'] = image['rgb'].unsqueeze(0).to(device)
+    if task == "caption":
+        question = pre_caption(question, max_words=50)
+    else:
         question = pre_question(question, max_words=50)
-        answer = model(image, [question], train=False, inference=config['inference'])
-        return answer[0]
+    return image, question
+
+def get_experts(config):
+    _, test_dataset = create_dataset('caption', config)
+    test_loader = create_loader(test_dataset, batch_size=1, num_workers=4, train=False)
+    experts, _ = next(iter(test_loader))
+    return experts
 
 
-inputs = [grImage(type="pil"), Textbox(placeholder="What is the color of the shirt?")]
-outputs = Textbox()
 
-title = "PrismerZ VQA"
-description = "Visual Question Answering with PrismerZ"
-article = ""
+def demo(
+        task: str = "vqa",
+        model_name: str = "prismerz_base",
+):
+    use_experts = "prismerz" not in model_name
+    if use_experts:
+        data_path = Path("helpers")
+        label_path = data_path / "labels"
+        label_path.mkdir(exist_ok=True, parents=True)
+    config = {
+        "prismer_model": model_name.replace("z", ""),
+        "experts": ["none"] if not use_experts else ['depth', 'normal', 'seg_coco', 'edge', 'obj_detection', 'ocr_detection'],
+        "data_path": data_path if use_experts else None,
+        "label_path": label_path if use_experts else None,
+        "freeze": "freeze_vision",
+        "image_resolution": 480,
+    }
+    if task == "vqa":
+        model = PrismerVQA(config)
+    elif task == "caption":
+        model = PrismerCaption(config)
+    else:
+        raise ValueError(f"Task {task} not supported")
+    state_dict = torch.load(f'logging/{task}_{model_name}/pytorch_model.bin', map_location=device)
+    model.load_state_dict(state_dict)
+    model.eval()
+    model = model.to(device)
 
-examples = [
-    ["http://images.cocodataset.org/val2017/000000039769.jpg", "How many cats are there?"],
-    ["http://images.cocodataset.org/val2017/000000039769.jpg", "What color is the blanket?"],
-]
+    def infer(image, question):
+        if use_experts:
+            prepare_image(config, image)
+            experts = get_experts(config)
+        im, question = prepare_inputs(image, question, task)
+        experts = im if not use_experts else experts
+        experts['rgb'] = experts['rgb'].to(device)
 
-gr.Interface(infer, inputs, outputs, title=title, description=description, article=article, examples=examples).launch()
+        with torch.no_grad():
+            if task == "caption":
+                answer = model(experts, prefix=question, train=False, inference='generate')
+            else:
+                answer = model(experts, [question], train=False, inference='generate')
+            return answer[0]
+        
+    model_title = "PrismerZ" if "prismerz" in model_name else "Prismer"
+    model_size = model_name.split("_")[-1].capitalize()
+    title = f"{model_title} {model_size} {task.capitalize()}"
+    if task == "vqa":
+        inputs = [grImage(type="pil"), Textbox(placeholder="What is the color of the shirt?")]
+        outputs = Textbox()
+        description = f"Visual Question Answering with {model_title} {model_size}"
+        article = ""
+        examples = [
+            ["http://images.cocodataset.org/val2017/000000039769.jpg", "How many cats are there?"],
+            ["http://images.cocodataset.org/val2017/000000039769.jpg", "What color is the blanket?"],
+        ]
+    else:
+        inputs = [grImage(type="pil"), Textbox(placeholder="A picture of", interactive=False)]
+        outputs = Textbox()
+        description = f"Image Captioning with {model_title} {model_size}"
+        article = ""
+        examples = [
+            ["http://images.cocodataset.org/val2017/000000039769.jpg", "A picture of"],
+        ]
 
+    gr.Interface(infer, inputs, outputs, title=title, description=description, article=article, examples=examples).launch()
+
+
+if __name__ == "__main__":
+    fire.Fire(demo)

--- a/app.py
+++ b/app.py
@@ -1,0 +1,44 @@
+import gradio as gr
+from gradio.components import Image as grImage
+from gradio.components import Textbox as Textbox
+from model.prismer_vqa import PrismerVQA
+import yaml
+from dataset.utils import *
+
+device = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
+
+with open('configs/gradio_vqa.yaml', 'r') as f:
+    config = yaml.load(f, Loader=yaml.Loader)
+
+model = PrismerVQA(config)
+state_dict = torch.load(f'logging/prismerz_vqa/pytorch_model.bin', map_location=device) # , map_location='cuda:0')
+model.load_state_dict(state_dict)
+tokenizer = model.tokenizer
+model.eval()
+
+transform = Transform(resize_resolution=config['image_resolution'], scale_size=[0.5, 1.0], train=False)
+
+
+def infer(image, question):
+    with torch.no_grad():
+        image = transform(image, None)
+        image['rgb'] = image['rgb'].unsqueeze(0).to(device)
+        question = pre_question(question, max_words=50)
+        answer = model(image, [question], train=False, inference=config['inference'])
+        return answer[0]
+
+
+inputs = [grImage(type="pil"), Textbox(placeholder="What is the color of the shirt?")]
+outputs = Textbox()
+
+title = "PrismerZ VQA"
+description = "Visual Question Answering with PrismerZ"
+article = ""
+
+examples = [
+    ["http://images.cocodataset.org/val2017/000000039769.jpg", "How many cats are there?"],
+    ["http://images.cocodataset.org/val2017/000000039769.jpg", "What color is the blanket?"],
+]
+
+gr.Interface(infer, inputs, outputs, title=title, description=description, article=article, examples=examples).launch()
+

--- a/configs/gradio_vqa.yaml
+++ b/configs/gradio_vqa.yaml
@@ -1,8 +1,0 @@
-experts: ['none']     # 'none' for PrismerZ
-
-image_resolution: 480
-prismer_model: 'prismer_base'  # 'prismer-large' for Prismer(Z)-Large
-inference: 'generate'
-
-freeze: 'freeze_vision'
-

--- a/configs/gradio_vqa.yaml
+++ b/configs/gradio_vqa.yaml
@@ -1,0 +1,8 @@
+experts: ['none']     # 'none' for PrismerZ
+
+image_resolution: 480
+prismer_model: 'prismer_base'  # 'prismer-large' for Prismer(Z)-Large
+inference: 'generate'
+
+freeze: 'freeze_vision'
+

--- a/download_checkpoints.py
+++ b/download_checkpoints.py
@@ -71,10 +71,14 @@ def download_checkpoints(
             )
             total_size += get_hf_file_metadata(url).size
         progress.print(f"[blue]Total download size: {total_size / 1e9:.2f} GB")
+
+        
         total_files = len(download_experts) + len(download_models)
         progress.add_task(f"[green]Downloading files", total=total_files)
         if download_experts:
-            expert_task = progress.add_task(f"[green]Downloading experts...", total=len(download_experts))
+            expert_task = progress.add_task(
+                f"[green]Downloading experts...", total=len(download_experts)
+                )
             for expert in download_experts:
                 path = Path(hf_hub_download(
                     filename=expert,
@@ -85,15 +89,17 @@ def download_checkpoints(
                 path.unlink()
                 progress.advance(expert_task)
         if download_models:
-            model_task = progress.add_task(f"[green]Downloading models...", total=len(download_models))
+            model_task = progress.add_task(
+                f"[green]Downloading models...", total=len(download_models)
+                )
             for model in download_models:
                 path = Path(hf_hub_download(
                     filename=f"pytorch_model.bin",
                     repo_id=_REPO_ID,
                     subfolder=model
                 ))
-                out_path = Path(f"{model}/pytorch_model.bin")
-                path.resolve().rename(out_path)
+                out_folder = Path("./logging")/model
+                path.resolve().rename(out_folder/"pytorch_model.bin")
                 path.unlink()
                 progress.advance(model_task)
         progress.print("[green]Done!")

--- a/download_checkpoints.py
+++ b/download_checkpoints.py
@@ -1,0 +1,103 @@
+from huggingface_hub import hf_hub_download, hf_hub_url, get_hf_file_metadata
+from huggingface_hub.utils import disable_progress_bars
+from pathlib import Path
+from rich.progress import Progress
+from fire import Fire
+
+_EXPERTS = [
+    "10_model.pth",
+    "Unified_learned_OCIM_RS200_6x+2x.pth",
+    "dpt_hybrid-midas-501f0c75.pt",
+    "icdar2015_hourglass88.pth",
+    "model_final_e0c58e.pkl",
+    "model_final_f07440.pkl",
+    "scannet.pt",
+]
+
+_MODELS = [
+    "vqa_prismerz_base",
+    "vqa_prismerz_large",
+    "caption_prismerz_base",
+    "caption_prismerz_large",
+    "vqa_prismer_base",
+    "vqa_prismer_large",
+    "caption_prismer_base",
+    "caption_prismer_large",
+    "pretrain_prismer_base",
+    "pretrain_prismer_large",
+    "pretrain_prismerz_base",
+    "pretrain_prismerz_large",
+]
+
+_REPO_ID = "lorenmt/prismer"
+
+def download_checkpoints(
+        download_experts=True,
+        download_models=["vqa_prismerz_base", "caption_prismerz_base"],
+        hide_tqdm=False,
+        force_redownload=False,
+):
+    if hide_tqdm:
+        disable_progress_bars()
+
+    download_experts = _EXPERTS if download_experts else []
+    if download_models:
+        assert all([m in _MODELS for m in download_models]), f"Invalid model name. Must be one of {_MODELS}"
+        download_models = _MODELS
+    else:
+        download_models = []
+
+    if not force_redownload:
+        download_experts = [e for e in download_experts if not Path(f"./experts/{e}").exists()]
+        download_models = [m for m in download_models if not Path(f"{m}/pytorch_model.bin").exists()]
+    
+    assert download_experts or download_models, "Nothing to download."
+
+    with Progress() as progress:
+        progress.print("[blue]Calculating download size...")
+        total_size = 0
+        for expert in download_experts:
+            url = hf_hub_url(
+                filename=expert,
+                repo_id=_REPO_ID,
+                subfolder="expert_weights"
+            )
+            total_size += get_hf_file_metadata(url).size
+        for model in download_models:
+            url = hf_hub_url(
+                filename=f"pytorch_model.bin",
+                repo_id=_REPO_ID,
+                subfolder=model
+            )
+            total_size += get_hf_file_metadata(url).size
+        progress.print(f"[blue]Total download size: {total_size / 1e9:.2f} GB")
+        total_files = len(download_experts) + len(download_models)
+        progress.add_task(f"[green]Downloading files", total=total_files)
+        if download_experts:
+            expert_task = progress.add_task(f"[green]Downloading experts...", total=len(download_experts))
+            for expert in download_experts:
+                path = Path(hf_hub_download(
+                    filename=expert,
+                    repo_id=_REPO_ID,
+                    subfolder="expert_weights"
+                ))
+                path.resolve().rename(f"./experts/{path.name}")
+                path.unlink()
+                progress.advance(expert_task)
+        if download_models:
+            model_task = progress.add_task(f"[green]Downloading models...", total=len(download_models))
+            for model in download_models:
+                path = Path(hf_hub_download(
+                    filename=f"pytorch_model.bin",
+                    repo_id=_REPO_ID,
+                    subfolder=model
+                ))
+                out_path = Path(f"{model}/pytorch_model.bin")
+                path.resolve().rename(out_path)
+                path.unlink()
+                progress.advance(model_task)
+        progress.print("[green]Done!")
+
+if __name__ == "__main__":
+    Fire(download_checkpoints)
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-torch
 git+https://github.com/openai/CLIP.git
 git+https://github.com/facebookresearch/detectron2.git@5aeb252b194b93dc2879b4ac34bc51a31b5aee13
 accelerate

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+torch
 git+https://github.com/openai/CLIP.git
 git+https://github.com/facebookresearch/detectron2.git@5aeb252b194b93dc2879b4ac34bc51a31b5aee13
 accelerate
@@ -13,3 +14,7 @@ pyclipper
 yacs
 pycocotools
 geffnet
+fire
+huggingface_hub
+rich
+gradio


### PR DESCRIPTION
Adds a versatile gradio demo in `app.py` that currently supports `vqa` and `caption` tasks as well as running with or without the use of the expert models on `Prismer` or `PrismerZ` models respectively. Saves the temporary image in the `helpers/images` folder so that the expert label generation scripts work. 
Run with:
```bash
python app.py --task="vqa" --model_name="prismer_base"
```
Sorry for the messy commit history on this, hope that's no issue. Open for any feedback. 